### PR TITLE
Fixed back end authentication

### DIFF
--- a/includes/DBinteractivity/createTicket.php
+++ b/includes/DBinteractivity/createTicket.php
@@ -11,13 +11,13 @@ include_once '../config.php';
 
 //Check if the user is authenticated
 //$auth is a variable from authenticate.php
-// if(!$auth)
-// {
-// 	// User is not authenticated
-// 	//Send an error message that was created in authenticate.php
-// 	echo $jsonMsg;
-// 	exit();
-// }
+if(!$auth)
+{
+	// User is not authenticated
+	//Send an error message that was created in authenticate.php
+	echo $jsonMsg;
+	exit();
+}
 
 // User is authenticated so create the ticket
 //Connect to the database

--- a/includes/DBinteractivity/login.php
+++ b/includes/DBinteractivity/login.php
@@ -78,7 +78,7 @@ if (isset($_POST['username']) && isset($_POST['password']))
 			$iat = time(); //Isued at
 			$jti = uniqid(); //Unique token id
 			$iss = 'chemRepair'; //Token issuer
-			$nbf = $iat + 10; //not before time
+			$nbf = $iat + 1; //not before time
 			$exp = $nbf + (60*60*24*30); // expires after 30 days
 
 			//Creating the token array
@@ -95,6 +95,7 @@ if (isset($_POST['username']) && isset($_POST['password']))
 			);
 
 			//Generate the jwt
+			JWT::$leeway = 15;
 			$jwt = JWT::encode($token, $jwtkey);
 
 			//put the jwt into a cookie


### PR DESCRIPTION
When creating JWT, token had start time that was less than the
current time so if users tried doing stuff too quickly, they
hit that limit. Limit was shortened to 1 second instead of 10